### PR TITLE
Convert a few things to use BeautifulSoup4 and requests, this should fix header parsing for a lot of stuff

### DIFF
--- a/README
+++ b/README
@@ -92,6 +92,5 @@ To Do
     TODO: finish holdem, needs testing and split pots probably don't work
     TODO: fix rate limiting problems with acro
     TODO: stock game: account for splits and reverse splits
-    TODO: replace urllib stuff with requests
     TODO: figure out how to reboot bot when a process locks up
     TODO: investigate Twisted

--- a/brainmeats/broca.py
+++ b/brainmeats/broca.py
@@ -265,7 +265,7 @@ class Broca(Dendrite):
             self.chat("Couldn't find anything")
             return
 
-        cont = soup(urlbase)
+        cont = soup(urlbase.text)
 
         heads = cont.findAll("dt")
         defs = cont.findAll("dd")
@@ -309,7 +309,7 @@ class Broca(Dendrite):
             self.chat("Fail")
             return
 
-        cont = soup(urlbase)
+        cont = soup(urlbase.text)
 
         if len(cont.findAll("p")) == 6:
             self.chat("No anagrams found.")
@@ -321,7 +321,7 @@ class Broca(Dendrite):
             content = content[2:-4]
             content = content.replace(": ,", ": ")
             self.chat(content)
-        
+
         # Usually not concerned with exceptions
         # in mongo, but this is bound to come up
         # again.

--- a/brainmeats/finance.py
+++ b/brainmeats/finance.py
@@ -1,4 +1,3 @@
-import simplejson
 import locale
 
 from autonomic import axon, category, help, Dendrite
@@ -45,7 +44,7 @@ class Finance(Dendrite):
             return
 
         try:
-            json = simplejson.loads(response)
+            json = response.json
         except:
             self.chat("Couldn't parse BTC data.")
             return
@@ -68,7 +67,7 @@ class Finance(Dendrite):
             return
 
         try:
-            json = simplejson.loads(response)
+            json = response.json
         except:
             self.chat("Couldn't parse LTC data.")
             return

--- a/brainmeats/nonsense.py
+++ b/brainmeats/nonsense.py
@@ -1,17 +1,14 @@
-import simplejson
-import urllib
-import urllib2
 import time
 import os
 
 from autonomic import axon, category, help, Dendrite
 from settings import STORAGE, ACROLIB, LOGDIR, SHORTENER, DISTASTE, NICK
-from secrets import FML_API 
-from util import colorize
+from secrets import FML_API
+from util import colorize, pageopen, shorten
 from random import choice
-from datastore import Drinker 
+from datastore import Drinker
 from xml.dom import minidom as dom
-    
+
 @category("nonsense")
 class Nonsense(Dendrite):
     def __init__(self, cortex):
@@ -44,35 +41,31 @@ class Nonsense(Dendrite):
     @help("<grab a little advice>")
     def advice(self):
         url = 'http://api.adviceslip.com/advice'
-        
+
         try:
-            headers = { 'User-Agent' : 'Mozilla/5.0' }
-            request = urllib2.Request(url, None, headers)
-            response = urllib2.urlopen(request).read()
-            json = simplejson.loads(response)
+            json = pageopen(url).json
         except:
             self.chat('Use a rubber if you sleep with dcross2\'s mother.')
             return
-        
+
         self.chat(json['slip']['advice'] + ".. in bed.")
-    
+
     @axon
     @help("SEARCHTERM <grab random fml entry>")
     def fml(self):
 
-        uri = 'http://api.fmylife.com'
-        lang = 'en'
-        
+        url = 'http://api.fmylife.com'
+        params = { 'language': 'en', 'key': FML_API }
+
         if self.values and self.values[0]:
-            path = '/view/search?'
-            search = "+".join(self.values)
-            url = uri + path + 'search=' + search + '&language=' + lang + '&key=' + FML_API
+            url += '/view/search'
+            params['search'] = "+".join(self.values)
         else:
-            path = '/view/random?'
-            url = uri + path + 'language=' + lang + '&key=' + FML_API
+            url += '/view/random'
 
         try:
-            raw = dom.parse(urllib.urlopen(url))
+            response = pageopen(url, params)
+            raw = dom.parse(response.text)
             if self.values and self.values[0]:
                 fml = choice(raw.getElementsByTagName("text")).firstChild.nodeValue
             else:
@@ -92,7 +85,7 @@ class Nonsense(Dendrite):
         url = 'http://itsthisforthat.com/api.php?text'
 
         try:
-            out = urllib.urlopen(url).read()
+            out = pageopen(url).text
             self.chat(out.lower().capitalize())
         except:
             self.chat("Done broke")
@@ -128,12 +121,12 @@ class Nonsense(Dendrite):
 
         drinker = Drinker.objects(name=kinder)
         if drinker:
-            drinker = drinker[0] 
+            drinker = drinker[0]
             rewards = drinker.rewards + 1
         else:
             drinker = Drinker(name=kinder)
             rewards = 1
-        
+
         drinker.rewards = rewards
         drinker.save()
 
@@ -169,8 +162,8 @@ class Nonsense(Dendrite):
     def aleksey(self):
         url = 'https://spreadsheets.google.com/feeds/list/0Auy4L1ZnQpdYdERZOGV1bHZrMEFYQkhKVHc4eEE3U0E/od6/public/basic?alt=json'
         try:
-            response = urllib2.urlopen(url).read()
-            json = simplejson.loads(response)
+            response = pageopen(url)
+            json = response.json
         except:
             self.chat('Somethin dun goobied.')
             return
@@ -212,8 +205,7 @@ class Nonsense(Dendrite):
     @help("URL <pull from distaste entries or add url to distate options>")
     def distaste(self):
         if self.values:
-            url = urllib.quote_plus(self.values[0])
-            roasted = urllib2.urlopen(SHORTENER + url).read()
+            roasted = shorten(url)
 
             open(DISTASTE, 'a').write(roasted + '\n')
             self.chat("Another one rides the bus")

--- a/brainmeats/nonsense.py
+++ b/brainmeats/nonsense.py
@@ -2,7 +2,7 @@ import time
 import os
 
 from autonomic import axon, category, help, Dendrite
-from settings import STORAGE, ACROLIB, LOGDIR, SHORTENER, DISTASTE, NICK
+from settings import STORAGE, ACROLIB, LOGDIR, DISTASTE, NICK
 from secrets import FML_API
 from util import colorize, pageopen, shorten
 from random import choice

--- a/brainmeats/reference.py
+++ b/brainmeats/reference.py
@@ -1,9 +1,6 @@
 import HTMLParser
-import simplejson
 import textwrap
-import urllib
 import os
-import requests
 
 from autonomic import axon, alias, category, help, Dendrite
 from BeautifulSoup import BeautifulSoup
@@ -43,7 +40,7 @@ class Reference(Dendrite):
                 }
 
         try:
-            request = requests.get(
+            request = pageopen(
                     'http://ajax.googleapis.com/ajax/services/search/web',
                     params=params)
             json = request.json()
@@ -54,11 +51,11 @@ class Reference(Dendrite):
         if not result.ok:
             self.chat("Bad status")
             return
-    
+
         if len(json["responseData"]["results"]) == 0:
             self.chat("No results")
             return
-            
+
         result = json["responseData"]["results"][0]
         title = result["titleNoFormatting"]
         link = result["unescapedUrl"]
@@ -92,12 +89,12 @@ class Reference(Dendrite):
             self.chat("Couldn't get weather.")
             return
 
-        if not response:
+        if not response.ok:
             self.chat("Couldn't get weather.")
             return
 
         try:
-            json = simplejson.loads(response)
+            json = response.json
             json = json['current_observation']
         except:
             self.chat("Couldn't parse weather.")
@@ -122,7 +119,7 @@ class Reference(Dendrite):
             return
 
         try:
-            request = requests.get('http://www.urbandictionary.com/define.php',
+            request = pageopen('http://www.urbandictionary.com/define.php',
                     params={'term': ' '.join(self.values)})
             soup = bs4(request.text,
                     convertEntities=BeautifulSoup.HTML_ENTITIES)

--- a/brainmeats/twitterapi.py
+++ b/brainmeats/twitterapi.py
@@ -27,7 +27,7 @@ class Twitterapi(Dendrite):
         if not self.values and not _message:
             self.chat("Tweet what?")
             return
-        
+
         if not _message:
             message = ' '.join(self.values)
         else:
@@ -37,3 +37,15 @@ class Twitterapi(Dendrite):
 
         if not _message:
             self.chat('Tweeted "' + status.text + '"')
+
+
+    @axon
+    @help("ID <retrieve the tweet with ID>")
+    def get_tweet(self, value):
+        status = self.api.GetStatus(value)
+
+        text = status.text
+        screen_name = status.user.screen_name
+        name = status.user.name
+        if status.text:
+            self.chat('%s (%s) tweeted: %s' % (name, screen_name, text))

--- a/cortex.py
+++ b/cortex.py
@@ -13,7 +13,7 @@ from time import mktime, localtime, sleep
 from random import choice, randint
 
 from settings import SAFE, NICK, CONTROL_KEY, LOG, LOGDIR, PATIENCE, \
-    SHORTENER, OWNER, REALNAME, SCAN
+    OWNER, REALNAME, SCAN
 from secrets import CHANNEL, DELICIOUS_PASS, DELICIOUS_USER, USERS
 from datastore import Drinker, connectdb
 from util import unescape, pageopen, shorten

--- a/cortex.py
+++ b/cortex.py
@@ -2,9 +2,6 @@ import base64
 import sys
 import os
 import re
-import urllib2
-import urllib
-import simplejson
 import shutil
 import pkgutil
 import requests
@@ -252,12 +249,12 @@ class Cortex:
         # This should somehow call twitterapi.get_tweet
         for url in urls:
             response = pageopen('https://api.twitter.com/1.1/statuses/show.json?id=%s' % url[1])
-            if not response:
+            if not response.ok:
                 self.chat("Couldn't retrieve Tweet.")
                 return
 
             try:
-                json = simplejson.loads(response)
+                json = response.json
             except:
                 self.chat("Couldn't parse Tweet.")
                 return
@@ -289,7 +286,7 @@ class Cortex:
                 title = "Couldn't get title"
                 roasted = "Couldn't roast"
 
-                urlbase = requests.get(url)
+                urlbase = pageopen(url)
                 if not urlbase.ok:
                     fubs += 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+BeautifulSoup4==4.3.2
 BeautifulSoup==3.2.1
 Flask==0.10
 Jinja2==2.7
@@ -17,7 +18,7 @@ numpy==1.5.1
 oauth2==1.5.211
 pymongo==2.3
 python-twitter==1.0.1
-requests==0.11.1
+requests==2.0.0
 simplejson==2.6.1
 six==1.3.0
 twilio==3.5.1

--- a/settings.py
+++ b/settings.py
@@ -30,7 +30,7 @@ ACROSCORE = STORAGE + "/acro/"
 # Misc
 
 CONTROL_KEY = "-"
-SHORTENER = "http://roa.st/api.php?roast="
+SHORTENER = "http://roa.st/api.php"
 PATIENCE = 7000
 REPO = "https://github.com/huntwelch/MongoBot"
 SMS_LOCKFILE = "/tmp/sms.lock"

--- a/util.py
+++ b/util.py
@@ -1,5 +1,3 @@
-import urllib
-import urllib2
 import re
 import htmlentitydefs
 import requests
@@ -62,7 +60,6 @@ def pageopen(url, params={}):
     try:
         headers = {'User-agent': '(Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36'}
         urlbase = requests.get(url, headers=headers, params=params)
-        urlbase = re.sub('\s+', ' ', urlbase.text).strip()
     except:
         return False
 
@@ -94,7 +91,7 @@ class Stock(object):
         url = singlestock + symbol + "'"
 
         try:
-            raw = dom.parse(urllib.urlopen(url))
+            raw = dom.parse(pageopen(url))
         except:
             return
 
@@ -107,7 +104,7 @@ class Stock(object):
     def extract(self, raw):
 
         elements = [e for e in raw.childNodes[0].childNodes[0].childNodes[0].childNodes if e.firstChild != None]
-        
+
         # in the future, can just change translation
         # point is to end up with an object that won't
         # change when the api changes.
@@ -170,7 +167,7 @@ class Stock(object):
             self.price = float(self._bid_realtime)
         else:
             self.price = float(self._last)
-            
+
         try:
             self.change = float(self._change)
             self.perc_change = float(self._perc_change[0:-1]) #trim % off
@@ -213,15 +210,14 @@ class Stock(object):
                 addon = pretty + ": " + self.stock[id]
                 message.append(addon)
 
-        link = urllib.quote("http://www.google.com/finance?client=ig&q=" + self.stock["symbol"])
+        link = "http://www.google.com/finance?client=ig&q=" + self.stock["symbol"]
         try:
-            opener = urllib2.build_opener()
-            roasted = opener.open(SHORTENER + link).read()
+            roasted = shorten(link)
             message.append(roasted)
         except:
             message.append("Can't link")
 
 
         output = ', '.join(message)
-    
+
         return output

--- a/util.py
+++ b/util.py
@@ -2,6 +2,7 @@ import urllib
 import urllib2
 import re
 import htmlentitydefs
+import requests
 from settings import CHANNEL, SHORTENER
 from xml.dom import minidom as dom
 
@@ -57,17 +58,23 @@ def colorize(text, color):
 
 
 
-def pageopen(url):
+def pageopen(url, params={}):
     try:
-        opener = urllib2.build_opener()
-        opener.addheaders = [('User-agent', 'Mozilla/5.0')]
-        urlbase = opener.open(url).read()
-        urlbase = re.sub('\s+', ' ', urlbase).strip()
+        headers = {'User-agent': '(Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36'}
+        urlbase = requests.get(url, headers=headers, params=params)
+        urlbase = re.sub('\s+', ' ', urlbase.text).strip()
     except:
         return False
 
     return urlbase
 
+def shorten(url):
+    try:
+        short_url = requests.get(SHORTENER, params={'roast': url}).text
+    except:
+        return ''
+
+    return short_url
 
 # Utility classes
 
@@ -213,7 +220,7 @@ class Stock(object):
             message.append(roasted)
         except:
             message.append("Can't link")
-            
+
 
         output = ', '.join(message)
     


### PR DESCRIPTION
This should either fix or totally break the following functions/cases:
- Add a -get_tweet call to retrieve a tweet
- Use requests and bs4 to get and parse urban dictionary info
- Use requests and bs4 to better parse out title lines and handle redirects much better I think (this needs tested)
- Add a roast function to make shortening urls even easier.
