### PR TITLE
Convert stocks, add rate limiting to chat, remove beautifulsoup3

### DIFF
--- a/brainmeats/broca.py
+++ b/brainmeats/broca.py
@@ -9,7 +9,7 @@ from settings import NICK, STORAGE, ACROLIB, LOGDIR, RAW_TEXT
 from datastore import Words, Learned, Structure
 from random import choice, randint
 from util import pageopen
-from BeautifulSoup import BeautifulSoup as soup
+from bs4 import BeautifulSoup as soup
 from wordnik import swagger, WordApi
 
 
@@ -247,9 +247,9 @@ class Broca(Dendrite):
             return
 
         word = self.values[0]
-        url = "http://www.etymonline.com/index.php?allowed_in_frame=0&search=" + word + "&searchmode=term"
+        params = {'allowed_in_frame': '0', 'searchmode': 'term', 'search': word}
 
-        urlbase = pageopen(url)
+        urlbase = pageopen("http://www.etymonline.com/index.php", params)
         if not urlbase:
             self.chat("Couldn't find anything")
             return

--- a/brainmeats/nonsense.py
+++ b/brainmeats/nonsense.py
@@ -1,6 +1,3 @@
-import time
-import os
-
 from autonomic import axon, category, help, Dendrite
 from settings import STORAGE, ACROLIB, LOGDIR, DISTASTE, NICK
 from secrets import FML_API

--- a/brainmeats/reference.py
+++ b/brainmeats/reference.py
@@ -1,13 +1,10 @@
-import HTMLParser
 import textwrap
-import os
 
 from autonomic import axon, alias, category, help, Dendrite
-from BeautifulSoup import BeautifulSoup
 from bs4 import BeautifulSoup as bs4
 from settings import REPO, NICK, SAFE
 from secrets import WEATHER_API
-from util import pageopen
+from util import unescape, pageopen
 
 
 @category("reference")
@@ -113,8 +110,7 @@ class Reference(Dendrite):
         try:
             request = pageopen('http://www.urbandictionary.com/define.php',
                                params={'term': ' '.join(self.values)})
-            soup = bs4(request.text,
-                       convertEntities=BeautifulSoup.HTML_ENTITIES)
+            soup = bs4(request.text)
         except:
             self.chat("parse error")
             return
@@ -128,12 +124,10 @@ class Reference(Dendrite):
         if defn:
             # Unfortunately, BeautifulSoup doesn't parse hexadecimal HTML
             # entities like &#x27; so use the parser for any stray entities.
-            parser = HTMLParser.HTMLParser()
-
             for paragraph in defn:
                 wrapped = textwrap.wrap(paragraph, 200)
                 for line in wrapped:
-                    self.chat(parser.unescape(line))
+                    self.chat(unescape(line))
         else:
             self.chat("couldn't find anything")
 

--- a/brainmeats/stockgame.py
+++ b/brainmeats/stockgame.py
@@ -34,6 +34,10 @@ class Stockgame(Dendrite):
             self.chat("Stock exchange %s DENIED!" % stock.exchange)
             return
 
+        if stock.price < 0.01:
+            self.chat("No penny stocks")
+            return
+
         drinker = Drinker.objects(name=whom).first()
         if not drinker:
             drinker = Drinker(name=whom)

--- a/brainmeats/twitterapi.py
+++ b/brainmeats/twitterapi.py
@@ -43,8 +43,8 @@ class Twitterapi(Dendrite):
     def get_tweet(self, value):
         status = self.api.GetStatus(value)
 
-        text = status.text
-        screen_name = status.user.screen_name
-        name = status.user.name
+        text = status['text']
+        screen_name = status['user']['screen_name']
+        name = status['user']['name']
         if status.text:
             self.chat('%s (%s) tweeted: %s' % (name, screen_name, text))

--- a/cortex.py
+++ b/cortex.py
@@ -9,11 +9,11 @@ from datetime import date, timedelta
 from time import mktime, localtime, sleep
 from random import randint
 
-from settings import NICK, CONTROL_KEY, LOG, LOGDIR, PATIENCE, \
+from settings import SAFE, NICK, CONTROL_KEY, LOG, LOGDIR, PATIENCE, \
     OWNER, REALNAME, SCAN
 from secrets import CHANNEL, DELICIOUS_PASS, DELICIOUS_USER, USERS
-from datastore import connectdb
-from util import unescape, pageopen, shorten
+from datastore import Drinker, connectdb
+from util import unescape, pageopen, shorten, RateLimited
 from autonomic import serotonin
 
 
@@ -371,6 +371,7 @@ class Cortex:
         except:
             self.sock.send('PRIVMSG ' + CHANNEL + ' :Having trouble saying that for some reason\n')
 
+    @RateLimited(5)
     def chat(self, message, target=False):
         if target:
             whom = target

--- a/cortex.py
+++ b/cortex.py
@@ -1,21 +1,18 @@
-import base64
-import sys
 import os
 import re
 import shutil
 import pkgutil
 import requests
 
-from BeautifulSoup import BeautifulSoup as soup
 from bs4 import BeautifulSoup as bs4
 from datetime import date, timedelta
 from time import mktime, localtime, sleep
-from random import choice, randint
+from random import randint
 
-from settings import SAFE, NICK, CONTROL_KEY, LOG, LOGDIR, PATIENCE, \
+from settings import NICK, CONTROL_KEY, LOG, LOGDIR, PATIENCE, \
     OWNER, REALNAME, SCAN
 from secrets import CHANNEL, DELICIOUS_PASS, DELICIOUS_USER, USERS
-from datastore import Drinker, connectdb
+from datastore import connectdb
 from util import unescape, pageopen, shorten
 from autonomic import serotonin
 

--- a/cortex.py
+++ b/cortex.py
@@ -231,7 +231,7 @@ class Cortex:
             self.command(nick, content)
             return
 
-        if content[:-2] in USERS and content[-2:] in ['--','++']:
+        if content[:-2] in USERS and content[-2:] in ['--', '++']:
             print "Active"
             self.values = [content[:-2]]
             if content[-2:] == '++':
@@ -239,7 +239,6 @@ class Cortex:
             if content[-2:] == '--':
                 self.commands.get('decrement')()
             return
-
 
         ur = 'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
         match_urls = re.compile(ur)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 BeautifulSoup4==4.3.2
-BeautifulSoup==3.2.1
 Flask==0.10
 Jinja2==2.7
 MarkupSafe==0.18

--- a/util.py
+++ b/util.py
@@ -1,5 +1,5 @@
 import re
-import htmlentitydefs
+import HTMLParser
 import requests
 from settings import CHANNEL, SHORTENER
 from xml.dom import minidom as dom
@@ -8,23 +8,8 @@ from xml.dom import minidom as dom
 # Utility functions
 
 def unescape(text):
-    def fixup(m):
-        text = m.group(0)
-        if text[:2] == "&#":
-            try:
-                if text[:3] == "&#x":
-                    return unichr(int(text[3:-1], 16))
-                else:
-                    return unichr(int(text[2:-1]))
-            except ValueError:
-                pass
-        else:
-            try:
-                text = unichr(htmlentitydefs.name2codepoint[text[1:-1]])
-            except KeyError:
-                pass
-        return text
-    return re.sub("&#?\w+;", fixup, text)
+    parser = HTMLParser.HTMLParser()
+    return parser.unescape(text)
 
 
 # instead of presuming to predict what

--- a/util.py
+++ b/util.py
@@ -6,6 +6,25 @@ from collections import OrderedDict
 
 
 # Utility functions
+def RateLimited(maxPerSecond):
+    # http://stackoverflow.com/questions/667508/whats-a-good-rate-limiting-algorithm
+    minInterval = 1.0 / float(maxPerSecond)
+
+    def decorate(func):
+        lastTimeCalled = [0.0]
+
+        def rateLimitedFunction(*args, **kargs):
+            elapsed = time.clock() - lastTimeCalled[0]
+            leftToWait = minInterval - elapsed
+            if leftToWait > 0:
+                time.sleep(leftToWait)
+            ret = func(*args, **kargs)
+            lastTimeCalled[0] = time.clock()
+            return ret
+        return rateLimitedFunction
+    return decorate
+
+
 def unescape(text):
     parser = HTMLParser.HTMLParser()
     return parser.unescape(text)


### PR DESCRIPTION
- Convert stocks to use the yahoo CSV api instead of YQL
- Should fix the -portfolio crashing things when its an invalid ticker
- Add a rate limiting function to chat so we don't get excess flood messages
- Remove beautifulsoup3, everything uses bs4
- Remove the over complicated unescape function and use the one in HTMLParser
- Fix (or break) the colorize function, also use it for the stock stuff now
- Fix a few new pep8 issues
- Convert things to use the requests format instead of string concat
