### PR TITLE
Error handling and boot changes

### DIFF
--- a/brainmeats/nonsense.py
+++ b/brainmeats/nonsense.py
@@ -205,8 +205,9 @@ class Nonsense(Dendrite):
         if self.values:
             roasted = shorten(url)
 
-            open(DISTASTE, 'a').write(roasted + '\n')
-            self.chat("Another one rides the bus")
+            if roasted:
+                open(DISTASTE, 'a').write(roasted + '\n')
+                self.chat("Another one rides the bus")
             return
 
         lines = []

--- a/brainmeats/stockgame.py
+++ b/brainmeats/stockgame.py
@@ -178,6 +178,10 @@ class Stockgame(Dendrite):
                 else:
                     net = -p.quantity * stock.price
                     collateral += 2 * p.quantity * p.price
+                if net >= 10000000:
+                    # Get rid of stupid twitter positions
+                    continue
+
                 total += net
 
             scores.append((drinker.name, cash, collateral,
@@ -232,6 +236,10 @@ class Stockgame(Dendrite):
                     net = p.quantity * (stock.price - p.price)
                 else:
                     net = p.quantity * (p.price - stock.price)
+
+                if net >= 10000000:
+                    # Get rid of stupid twitter positions
+                    continue
 
                 self.chat("%8s %10s %10d %10.02f %10.02f %10.02f" %
                           (p.type, p.symbol, p.quantity, p.price, stock.price,

--- a/cortex.py
+++ b/cortex.py
@@ -299,9 +299,9 @@ class Cortex:
                     self.chat("Total fail")
                     return
 
-                try:
-                    roasted = shorten(url)
-                except:
+                roasted = shorten(url)
+                if not roasted:
+                    roasted = ''
                     fubs += 1
 
                 ext = urlbase.headers['content-type'].split('/')[1]

--- a/doctor.py
+++ b/doctor.py
@@ -4,7 +4,6 @@ from time import mktime, localtime, sleep
 
 print "The doctor is in"
 while True:
-    sleep(10)
     pulse = open('/tmp/bot.pulse', 'r')
     lastpulse = pulse.readline()
     if mktime(localtime()) - float(lastpulse) > 25:
@@ -12,3 +11,4 @@ while True:
         os.system("ps ax | grep 'medulla.py' | grep -v grep | awk '{print $1}' | xargs kill")
         os.system("python medulla.py >> hippocampus/log/sys.log 2>>hippocampus/log/error.log &")
         print "It's cool, we had the thingy"
+    sleep(10)

--- a/lightning.sh
+++ b/lightning.sh
@@ -2,5 +2,4 @@
 
 echo "IT'S ALIVE"
 
-python medulla.py >> hippocampus/log/sys.log 2>>hippocampus/log/error.log &
 python doctor.py

--- a/util.py
+++ b/util.py
@@ -65,17 +65,18 @@ def pageopen(url, params={}):
     except requests.exceptions.RequestException as e:
         print e
         return False
+    except:
+        return False
 
     return urlbase
 
 
 def shorten(url):
-    try:
-        short_url = requests.get(SHORTENER, params={'roast': url}, timeout=5).text
-    except:
-        return ''
+    short_url = pageopen(SHORTENER, params={'roast': url})
 
-    return short_url
+    if short_url
+        return short_url.text
+    return ''
 
 
 # Utility classes


### PR DESCRIPTION
Better error handling in pageopen()
Change the way doctor and lightning interact. Doctor does all the work now and lightning only runs doctor.
Remove stock positions of more than 10M from consideration
Make shorten() use pageopen() and handle failures differently
